### PR TITLE
Fix for a bug with selecting a syssuperfinfo file

### DIFF
--- a/check_mssql_database.py
+++ b/check_mssql_database.py
@@ -27,8 +27,8 @@ except:
     import pickle
 from optparse import OptionParser, OptionGroup
 
-BASE_QUERY = "SELECT cntr_value FROM sysperfinfo WHERE counter_name='%s' AND instance_name='%%s';"
-DIVI_QUERY = "SELECT cntr_value FROM sysperfinfo WHERE counter_name LIKE '%s%%%%' AND instance_name='%%s';"
+BASE_QUERY = "SELECT cntr_value FROM sys.sysperfinfo WHERE counter_name='%s' AND instance_name='%%s';"
+DIVI_QUERY = "SELECT cntr_value FROM sys.sysperfinfo WHERE counter_name LIKE '%s%%%%' AND instance_name='%%s';"
 
 MODES     = {
     


### PR DESCRIPTION
Multiple people have reported an issue with this;

logtruncs failed with: SQL Server message 208, severity 16, state 1, line 1:
Invalid object name 'sysperfinfo'.
DB-Lib error message 208, severity 16:
General SQL Server error: Check messages from the SQL Server

We received this fix from another user.
